### PR TITLE
Updating sretrchr/testify version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/go-task/slim-sprig
 
 go 1.13
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/stretchr/testify v1.6.1
-)
+require github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -4,9 +4,14 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to sprig.

Sprig is a maintained project. Triaging and responding to pull requests happens several times per year rather than daily or weekly.
-->
This PR updates sretchr/testify to the latest version. The main reason for this is because of a vulnerability in gopkg.in/yaml.v3 which was fixed v3.0.1.

```
go/pkg/mod/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572/go.mod (gomod)
==========================================================================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬───────────────────────────────────┬───────────────────────────────────┬─────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │         Installed Version         │           Fixed Version           │                          Title                          │
├──────────────────┼────────────────┼──────────┼───────────────────────────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────┤
│ gopkg.in/yaml.v3 │ CVE-2022-28948 │ HIGH     │ 3.0.0-2020031[310](https://github.com/zuvaai/aitk-mlc/actions/runs/4535412124/jobs/7990827947?pr=78#step:11:317)2051-9f266ea9e77c │ 3.0.0-20220521103104-8f96da9f5d5e │ golang-gopkg-yaml: crash when attempting to deserialize │
│                  │                │          │                                   │                                   │ invalid input                                           │
│                  │                │          │                                   │                                   │ https://avd.aquasec.com/nvd/cve-2022-28948              │
└──────────────────┴────────────────┴──────────┴───────────────────────────────────┴───────────────────────────────────┴─────────────────────────────────────────────────────────┘
```