### PR TITLE
test if input string is ipv6, ipv4

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -9,3 +9,21 @@ The `getHostByName` receives a domain name and returns the ip address.
 ```
 getHostByName "www.google.com" would return the corresponding ip address of www.google.com
 ```
+
+## isIPv4
+
+The `isIPv4` returns `true` if a string is an IPv4 address.
+
+```
+isIPv4 "192.168.1.100" returns `true`
+isIPv4 "fe80::1ff:fe23:4567:890a" returns `false`
+```
+
+## isIPv6
+
+The `isIPv6` returns `true` if a string is an IPv6 address.
+
+```
+isIPv4 "192.168.1.100" returns `false`
+isIPv4 "fe80::1ff:fe23:4567:890a" returns `true`
+```

--- a/functions.go
+++ b/functions.go
@@ -18,8 +18,7 @@ import (
 //
 // Use this to pass the functions into the template engine:
 //
-// 	tpl := template.New("foo").Funcs(sprig.FuncMap()))
-//
+//	tpl := template.New("foo").Funcs(sprig.FuncMap()))
 func FuncMap() template.FuncMap {
 	return HtmlFuncMap()
 }
@@ -314,4 +313,8 @@ var genericMap = map[string]interface{}{
 	// URLs:
 	"urlParse": urlParse,
 	"urlJoin":  urlJoin,
+
+	// IP Addresses:
+	"isIPv4": isIPv4,
+	"isIPv6": isIPv6,
 }

--- a/network.go
+++ b/network.go
@@ -3,10 +3,21 @@ package sprig
 import (
 	"math/rand"
 	"net"
+	"strings"
 )
 
 func getHostByName(name string) string {
 	addrs, _ := net.LookupHost(name)
-	//TODO: add error handing when release v3 comes out
+	// TODO: add error handing when release v3 comes out
 	return addrs[rand.Intn(len(addrs))]
+}
+
+func isIPv6(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return netIP != nil && netIP.To4() == nil
+}
+
+func isIPv4(input string) bool {
+	netIP := net.ParseIP(input)
+	return netIP != nil && netIP.To4() != nil && !strings.Contains(input, ":")
 }

--- a/network_test.go
+++ b/network_test.go
@@ -16,3 +16,31 @@ func TestGetHostByName(t *testing.T) {
 	assert.NotNil(t, ip)
 	assert.NotEmpty(t, ip)
 }
+
+func TestIsIPv6(t *testing.T) {
+	tpl := `{{"2001:db8::68" | isIPv6}}`
+	isIPv6, _ := runRaw(tpl, nil)
+	assert.Equal(t, "true", isIPv6)
+
+	tpl = `{{"2001:db8::68/64" | isIPv6}}`
+	isIPv6, _ = runRaw(tpl, nil)
+	assert.Equal(t, "false", isIPv6)
+
+	tpl = `{{"192.168.1.100" | isIPv6}}`
+	isIPv6, _ = runRaw(tpl, nil)
+	assert.Equal(t, "false", isIPv6)
+}
+
+func TestIsIPv4(t *testing.T) {
+	tpl := `{{"192.168.1.100" | isIPv4}}`
+	isIPv4, _ := runRaw(tpl, nil)
+	assert.Equal(t, "true", isIPv4)
+
+	tpl = `{{"192.168.1.100/32" | isIPv4}}`
+	isIPv4, _ = runRaw(tpl, nil)
+	assert.Equal(t, "false", isIPv4)
+
+	tpl = `{{"::FFFF:192.0.2.0" | isIPv4}}`
+	isIPv4, _ = runRaw(tpl, nil)
+	assert.Equal(t, "false", isIPv4)
+}


### PR DESCRIPTION
Adding functions to test if an input string is an IPv4 or IPv6 address.
Related: https://github.com/kubernetes-sigs/external-dns/pull/3949