### PR TITLE
feat: add osAbs function

### DIFF
--- a/docs/paths.md
+++ b/docs/paths.md
@@ -112,3 +112,14 @@ The above returns `.bar` on Linux and Windows, respectively.
 ### osIsAbs
 
 To check whether a file path is absolute, use `osIsAbs`.
+
+### osAbs
+
+Return the absolute representation of a path. If the path is not absolute, it will be joined with the current working directory.
+
+```
+osAbs "foo/bar"
+osAbs "../config"
+```
+
+The above returns the absolute path based on the current working directory, e.g. `/home/user/foo/bar`.

--- a/functions.go
+++ b/functions.go
@@ -245,6 +245,10 @@ var genericMap = map[string]interface{}{
 	"osDir":   filepath.Dir,
 	"osExt":   filepath.Ext,
 	"osIsAbs": filepath.IsAbs,
+	"osAbs": func(p string) string {
+		abs, _ := filepath.Abs(p)
+		return abs
+	},
 
 	// Encoding:
 	"b64enc": base64encode,


### PR DESCRIPTION
adds osAbs to the path functions — wraps filepath.Abs and returns the absolute path of the input. mentioned in go-task/task#2681 as a missing function that users need for path resolution in Taskfiles