### PR TITLE
drop deprecated rand.Seed init hook

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -3,15 +3,9 @@ package sprig
 import (
 	"bytes"
 	"encoding/json"
-	"math/rand"
 	"reflect"
 	"strings"
-	"time"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // dfault checks whether `given` is set, and returns default if not set.
 //


### PR DESCRIPTION
Closes #22.

\`math/rand\` self-seeds with a random value as of Go 1.20, and the deprecation notice on \`rand.Seed\` says basically \"don't bother calling this anymore.\" go.mod already requires go 1.20 so the init hook is dead weight, and gopls is now flagging it as deprecated.